### PR TITLE
:recycle: refactor: retirado códigos duplicados

### DIFF
--- a/cypress/e2e/duplication/sample1.cy.js
+++ b/cypress/e2e/duplication/sample1.cy.js
@@ -1,5 +1,5 @@
 describe('Code duplication bad practice - repetitive steps', () => {
-  it('searches by typing and hitting enter', () => {
+  beforeEach(() => {
     cy.intercept(
       'GET',
       '**/search**'
@@ -10,8 +10,12 @@ describe('Code duplication bad practice - repetitive steps', () => {
 
     cy.get('input[type="text"]')
       .should('be.visible')
+      .as('searchField')
       .and('have.value', 'redux')
       .clear()
+  })
+  it('searches by typing and hitting enter', () => {
+    cy.get('@searchField')
       .type('frontend testing{enter}')
 
     cy.wait('@getStories')
@@ -21,18 +25,7 @@ describe('Code duplication bad practice - repetitive steps', () => {
   })
 
   it('searches by typing and pressing the search button', () => {
-    cy.intercept(
-      'GET',
-      '**/search**'
-    ).as('getStories')
-
-    cy.visit('https://hackernews-seven.vercel.app')
-    cy.wait('@getStories')
-
-    cy.get('input[type="text"]')
-      .should('be.visible')
-      .and('have.value', 'redux')
-      .clear()
+    cy.get('@searchField')
       .type('frontend testing')
 
     cy.contains('button', 'Search')

--- a/cypress/e2e/duplication/sample2.cy.js
+++ b/cypress/e2e/duplication/sample2.cy.js
@@ -15,23 +15,16 @@ describe('Code duplication bad practice - repetitive tests', () => {
       .clear()
   })
 
-  it('searches for "reactjs"', () => {
-    cy.get('@searchField')
-      .type('reactjs{enter}')
+  const terms = ['reactjs', 'vuejs', 'angularjs']
 
-    cy.wait('@getStories')
+  terms.forEach(terms => {
+    it(`searches for "${terms}"`, () => {
+      cy.search(terms)
 
-    cy.get('.table-row')
-      .should('have.length', 100)
-  })
+      cy.wait('@getStories')
 
-  it('searches for "vuejs"', () => {
-    cy.get('@searchField')
-      .type('vuejs{enter}')
-
-    cy.wait('@getStories')
-
-    cy.get('.table-row')
-      .should('have.length', 100)
+      cy.get('.table-row')
+        .should('have.length', 100)
+    })
   })
 })

--- a/cypress/e2e/duplication/sample3.cy.js
+++ b/cypress/e2e/duplication/sample3.cy.js
@@ -10,22 +10,12 @@ describe('Code duplication bad practice - repetitive actions and assertions', ()
   })
 
   it('searches for the same term 3 times', () => {
-    cy.search('cypress.io')
+    Cypress._.times(3, () => {
+      cy.search('cypress.io')
 
-    cy.get('.table-row')
-      .its('length')
-      .should('be.at.least', 1)
-
-    cy.search('cypress.io')
-
-    cy.get('.table-row')
-      .its('length')
-      .should('be.at.least', 1)
-
-    cy.search('cypress.io')
-
-    cy.get('.table-row')
-      .its('length')
-      .should('be.at.least', 1)
+      cy.get('.table-row')
+        .its('length')
+        .should('be.at.least', 1)
+    })
   })
 })

--- a/cypress/e2e/duplication/sample4.cy.js
+++ b/cypress/e2e/duplication/sample4.cy.js
@@ -4,8 +4,6 @@ describe('Code duplication bad practice - multiple checks', () => {
   })
  
   it('checks all checkboxes from a specific fieldset', () => {
-    cy.get('#friend').check()
-    cy.get('#publication').check()
-    cy.get('#social-media').check()
+    cy.get('fieldset div input[type="checkbox"]').check()
   })
 })


### PR DESCRIPTION
testes foram refatorados por estarem com códigos duplicados, deixado o código mais limpo e genérico.